### PR TITLE
Remove "2020.3.24f1" from push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,6 @@ jobs:
         projectPath:
           - .
         unityVersion:
-          - 2020.3.24f1
           - 2021.2.4f1
         targetPlatform:
           - StandaloneWindows64


### PR DESCRIPTION
# Changes
- Remove "2020.3.24f1" from push.yml
  - The build for "2020.3.24f1" will fail because the version doesn't have "FeatureSets"