### PR TITLE
Unuse the nagation pattern of "is operator" in EquatableData

### DIFF
--- a/Assets/Tests/SampleType/EquatableData.cs
+++ b/Assets/Tests/SampleType/EquatableData.cs
@@ -18,7 +18,7 @@ namespace Tests.SampleType
                 return false;
             }
 
-            if (obj is not EquatableData other)
+            if (!(obj is EquatableData other))
             {
                 return false;
             }


### PR DESCRIPTION
# Changes
- Unuse the nagation pattern of "is operator" in EquatableData
  - For C# 7.0 (Unity 2019)